### PR TITLE
fix: update href formatter to handle mdx correctly

### DIFF
--- a/gatsby-philipps-foam-theme/src/hooks/usePageIndex.js
+++ b/gatsby-philipps-foam-theme/src/hooks/usePageIndex.js
@@ -1,7 +1,7 @@
 import { graphql, useStaticQuery } from 'gatsby';
 
 const getHref = (relativePath) => {
-  let href = relativePath.replace(/\.md|\.mdx/, '');
+  let href = relativePath.replace(/(\.mdx)|(\.md)/g, '');
   // pages from subdir must add leading slash
   if (href.match(/\//g) > 0 && href.charAt(0) !== '/') {
     href = `/${href}`;


### PR DESCRIPTION
Greetings,

The link transformer have a bug where `foobar.mdx` href will be `foobarx` which cause an errors on routing. I updated the regex and tested locally with `md` and `mdx`. Let me know if there is a preferred logic that you would like to implement instead

Thank you for maintaining this :)